### PR TITLE
Fix coordinator dashboard route and clean imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import Login from "./pages/login";
 import RegisterEstudiante from "./pages/registerEstudiantes";
 import DashboardEstudiante from "./pages/dashboardEstudiante";
-import DashboardProfesor from "./pages/dashboardCoordinador";
+import DashboardCoordinador from "./pages/dashboardCoordinador";
 
 
 function App() {
@@ -23,9 +23,9 @@ function App() {
             )
          }
          />
-        <Route path="/dashboard-coordiandor" element={ isLoggedIn && rol === 'coordinador'
+        <Route path="/dashboard-coordinador" element={ isLoggedIn && rol === 'coordinador'
             ? (
-            <DashboardProfesor />
+            <DashboardCoordinador />
             ): (
             <Navigate to='/login'/>
             )

--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -1,6 +1,6 @@
 import {
-  AppBar, Toolbar, Typography, Button, Box, Container, Drawer, List, 
-  ListItem,ListItemButton, ListItemIcon, ListItemText, IconButton, Divider
+  AppBar, Toolbar, Typography, Button, Box, Container, Drawer, List,
+  ListItem,ListItemButton, ListItemText, IconButton
 } from "@mui/material";
 import type { ReactNode } from "react";
 import { useNavigate, Link } from "react-router-dom";

--- a/frontend/src/pages/dashboardCoordinador.tsx
+++ b/frontend/src/pages/dashboardCoordinador.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-export default function DashboardProfesor(){
+export default function DashboardCoordinador(){
     return(
         <div>
-            <h2>Dashboard Profesor</h2>
+            <h2>Dashboard Coordinador</h2>
             <p>hola</p>
         </div>
     )


### PR DESCRIPTION
## Summary
- Correct coordinator dashboard path to match navigation
- Rename coordinator dashboard component and heading
- Remove unused material-ui imports to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf914c3be4832b93133e681388cb56