### PR TITLE
Ensure student practice page keeps dashboard navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Login from "./pages/login";
 import RegisterEstudiante from "./pages/registerEstudiantes";
 import DashboardEstudiante from "./pages/dashboardEstudiante";
 import DashboardCoordinador from "./pages/dashboardCoordinador";
+import FichasPracticas from "./pages/fichasPracticas";
 
 function App() {
   const isLoggedIn = !!localStorage.getItem("token");
@@ -28,6 +29,15 @@ function App() {
           element={
             isLoggedIn && rol === "coordinador"
               ? <DashboardCoordinador />
+              : <Navigate to="/login" />
+          }
+        />
+
+        <Route
+          path="/fichas-practicas"
+          element={
+            isLoggedIn && rol === "estudiante"
+              ? <FichasPracticas />
               : <Navigate to="/login" />
           }
         />

--- a/frontend/src/pages/fichasPracticas.tsx
+++ b/frontend/src/pages/fichasPracticas.tsx
@@ -1,0 +1,9 @@
+import DashboardTemplate from "../components/DashboardTemplate";
+
+export default function FichasPracticas() {
+  return (
+    <DashboardTemplate title="Mis Prácticas">
+      <h1>Mis Prácticas</h1>
+    </DashboardTemplate>
+  );
+}


### PR DESCRIPTION
## Summary
- add student practice page using DashboardTemplate
- register `/fichas-practicas` route so sidebar remains accessible

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfbba4523c832b95680a22cd1ca825