### PR TITLE
Add Empresas page and coordinator dashboard navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import Login from "./pages/login";
 import RegisterEstudiante from "./pages/registerEstudiantes";
 import DashboardEstudiante from "./pages/dashboardEstudiante";
 import DashboardCoordinador from "./pages/dashboardCoordinador";
+import FichasPracticas from "./pages/fichasPracticas";
+import Empresas from "./pages/empresas";
 
 function App() {
   const isLoggedIn = !!localStorage.getItem("token");
@@ -28,6 +30,24 @@ function App() {
           element={
             isLoggedIn && rol === "coordinador"
               ? <DashboardCoordinador />
+              : <Navigate to="/login" />
+          }
+        />
+
+        <Route
+          path="/fichas-practicas"
+          element={
+            isLoggedIn && rol === "estudiante"
+              ? <FichasPracticas />
+              : <Navigate to="/login" />
+          }
+        />
+
+        <Route
+          path="/empresas"
+          element={
+            isLoggedIn && rol === "estudiante"
+              ? <Empresas />
               : <Navigate to="/login" />
           }
         />

--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -59,25 +59,36 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
         <Toolbar />
         <Box sx={{ overflow: 'auto', mt: 2 }}>
           <List>
-            <ListItem disablePadding>
-                <ListItemButton component={Link} to="/dashboard-estudiante">
-                {/* <ListItemIcon><DashboardIcon /></ListItemIcon> */}
-                <ListItemText primary="Dashboard" />
+            {userRole === "estudiante" && (
+              <>
+                <ListItem disablePadding>
+                  <ListItemButton component={Link} to="/dashboard-estudiante">
+                    {/* <ListItemIcon><DashboardIcon /></ListItemIcon> */}
+                    <ListItemText primary="Dashboard" />
+                  </ListItemButton>
+                </ListItem>
+                <ListItem disablePadding>
+                  <ListItemButton component={Link} to="/fichas-practicas">
+                    {/* <ListItemIcon><AssignmentIcon /></ListItemIcon> */}
+                    <ListItemText primary="Mis Prácticas" />
+                  </ListItemButton>
+                </ListItem>
+                <ListItem disablePadding>
+                  <ListItemButton component={Link} to="/empresas">
+                    {/* <ListItemIcon><BusinessIcon /></ListItemIcon> */}
+                    <ListItemText primary="Empresas" />
+                  </ListItemButton>
+                </ListItem>
+              </>
+            )}
+            {userRole === "coordinador" && (
+              <ListItem disablePadding>
+                <ListItemButton component={Link} to="/dashboard-coordinador">
+                  <ListItemText primary="Dashboard" />
                 </ListItemButton>
-            </ListItem>
-            <ListItem disablePadding>
-                <ListItemButton component={Link} to="/fichas-practicas">
-                {/* <ListItemIcon><AssignmentIcon /></ListItemIcon> */}
-                <ListItemText primary="Mis Prácticas" />
-                </ListItemButton>
-            </ListItem>
-            <ListItem disablePadding>
-                <ListItemButton component={Link} to="/empresas">
-                {/* <ListItemIcon><BusinessIcon /></ListItemIcon> */}
-                <ListItemText primary="Empresas" />
-                </ListItemButton>
-            </ListItem>
-            </List>
+              </ListItem>
+            )}
+          </List>
         </Box>
       </Drawer>
 

--- a/frontend/src/pages/dashboardCoordinador.tsx
+++ b/frontend/src/pages/dashboardCoordinador.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import DashboardTemplate from "../components/DashboardTemplate";
 
 export default function DashboardCoordinador(){
     return(
-        <div>
+        <DashboardTemplate title="Panel de coordinador">
             <h2>Dashboard Coordinador</h2>
             <p>hola</p>
-        </div>
+        </DashboardTemplate>
     )
 }

--- a/frontend/src/pages/empresas.tsx
+++ b/frontend/src/pages/empresas.tsx
@@ -1,0 +1,9 @@
+import DashboardTemplate from "../components/DashboardTemplate";
+
+export default function Empresas() {
+  return (
+    <DashboardTemplate title="Empresas">
+      <h1>Empresas</h1>
+    </DashboardTemplate>
+  );
+}

--- a/frontend/src/pages/fichasPracticas.tsx
+++ b/frontend/src/pages/fichasPracticas.tsx
@@ -1,0 +1,9 @@
+import DashboardTemplate from "../components/DashboardTemplate";
+
+export default function FichasPracticas() {
+  return (
+    <DashboardTemplate title="Mis Prácticas">
+      <h1>Mis Prácticas</h1>
+    </DashboardTemplate>
+  );
+}


### PR DESCRIPTION
## Summary
- add Empresas page using DashboardTemplate
- apply DashboardTemplate to coordinator panel with role-aware menu
- register `/empresas` route for student dashboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfbba4523c832b95680a22cd1ca825