### PR TITLE
Add Docker configuration for backend and Vite frontend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.py[cod]
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+# Backend development Dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  backend:
+    build: ./backend
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    command: npm run dev -- --host
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "5173:5173"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Frontend development Dockerfile
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- set up Python backend Dockerfile and ignore file
- add Vite frontend Dockerfile and ignore file
- orchestrate services with docker-compose

## Testing
- `npm run lint` *(fails: Parsing error: JSX element 'Routes' has no corresponding closing tag)*
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf9acc64832bb2dd095c315739f3