### PR TITLE
Add authentication context and provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,11 @@ import DashboardEstudiante from "./pages/dashboardEstudiante";
 import DashboardCoordinador from "./pages/dashboardCoordinador";
 import FichasPracticas from "./pages/fichasPracticas";
 import Empresas from "./pages/empresas";
+import { useAuth } from "./context/AuthContext";
 
 function App() {
-  const isLoggedIn = !!localStorage.getItem("token");
-  const rol = localStorage.getItem("rol");
+  const { token, rol } = useAuth();
+  const isLoggedIn = !!token;
 
   return (
     <Router>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface AuthContextType {
+  token: string | null;
+  rol: string | null;
+  setAuth: (token: string, rol: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(localStorage.getItem("token"));
+  const [rol, setRol] = useState<string | null>(localStorage.getItem("rol"));
+
+  const setAuth = (newToken: string, newRol: string) => {
+    localStorage.setItem("token", newToken);
+    localStorage.setItem("rol", newRol);
+    setToken(newToken);
+    setRol(newRol);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("rol");
+    setToken(null);
+    setRol(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, rol, setAuth, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,15 @@ import App from "./App";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import theme from "./theme/theme";
+import { AuthProvider } from "./context/AuthContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <CssBaseline/>
-      <App/>
+      <CssBaseline />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>
-)
+);


### PR DESCRIPTION
## Summary
- create auth context to manage token/rol and session updates
- wrap app with AuthProvider
- consume auth context in App instead of direct localStorage access

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd620e330832bae8b49d615428b4d