### PR TITLE
refactor: use useAuth hook across dashboard

### DIFF
--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -5,6 +5,7 @@ import {
 import type { ReactNode } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
+import useAuth from "../hooks/useAuth";
 // Necesitarás importar iconos, por ejemplo:
 // import DashboardIcon from '@mui/icons-material/Dashboard';
 // import AssignmentIcon from '@mui/icons-material/Assignment';
@@ -19,13 +20,7 @@ interface DashboardTemplateProps {
 export default function DashboardTemplate({ title, children }: DashboardTemplateProps) {
   const navigate = useNavigate();
   const [drawerOpen, setDrawerOpen] = useState(true);
-  const username = localStorage.getItem('username') || 'Usuario';
-  const userRole = localStorage.getItem('rol');
-
-  const handleLogout = () => {
-    localStorage.clear();
-    navigate("/login");
-  };
+  const { rol, username, logout } = useAuth();
 
   const toggleDrawer = () => {
     setDrawerOpen(!drawerOpen);
@@ -59,7 +54,7 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
         <Toolbar />
         <Box sx={{ overflow: 'auto', mt: 2 }}>
           <List>
-            {userRole === "estudiante" && (
+            {rol === "estudiante" && (
               <>
                 <ListItem disablePadding>
                   <ListItemButton component={Link} to="/dashboard-estudiante">
@@ -81,7 +76,7 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
                 </ListItem>
               </>
             )}
-            {userRole === "coordinador" && (
+            {rol === "coordinador" && (
               <ListItem disablePadding>
                 <ListItemButton component={Link} to="/dashboard-coordinador">
                   <ListItemText primary="Dashboard" />
@@ -111,10 +106,10 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
             
             {/* Indicador de usuario actual */}
             <Typography variant="body2" color="inherit" sx={{ mr: 2 }}>
-              {username} ({userRole})
+              {username} ({rol})
             </Typography>
             
-            <Button color="inherit" onClick={handleLogout}>
+            <Button color="inherit" onClick={logout}>
               Cerrar Sesión
             </Button>
           </Toolbar>

--- a/frontend/src/components/logout.tsx
+++ b/frontend/src/components/logout.tsx
@@ -1,15 +1,10 @@
-import { useNavigate } from "react-router-dom";
+import useAuth from "../hooks/useAuth";
 
-export default function Logout(){
-    const navigate = useNavigate();
-    const handleLogout = () => {
-        localStorage.removeItem("token");
-        localStorage.removeItem("rol");
-        navigate("/login")
-    };
+export default function Logout() {
+    const { logout } = useAuth();
     return (
-        <button onClick={handleLogout}>
+        <button onClick={logout}>
             Cerrar Sesion
         </button>
-    )
+    );
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface AuthResult {
+  rol: string | null;
+  username: string;
+  logout: () => void;
+}
+
+export default function useAuth(): AuthResult {
+  const navigate = useNavigate();
+
+  const rol = localStorage.getItem("rol");
+  const username = localStorage.getItem("username") || "Usuario";
+
+  const logout = useCallback(() => {
+    localStorage.clear();
+    navigate("/login");
+  }, [navigate]);
+
+  return { rol, username, logout };
+}


### PR DESCRIPTION
## Summary
- create `useAuth` hook to expose `rol`, `username` and `logout`
- apply hook in `DashboardTemplate` for auth data and signout
- update `Logout` component to use `useAuth.logout`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfd6d1e584832b9dcbdf8f35a6d8d9