### PR TITLE
Setup frontend Docker workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,24 @@ ALTER TABLE estudiantes DISABLE ROW LEVEL SECURITY;
 
 ## 🚀 Instalación y Uso
 
+### Opción 1: con Docker (recomendado)
+
+1. Asegúrate de tener instalados **Docker** y **Docker Compose v2**.
+2. Verifica que el archivo `frontend/.env` contenga `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY`.
+3. Desde la raíz del proyecto levanta el servicio:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Esto construirá la imagen (incluyendo dependencias) y dejará corriendo Vite en `http://localhost:5173`.
+
+4. Cuando quieras detener el entorno, ejecuta `docker compose down`.
+
+> 🛠️ La primera vez el contenedor instala automáticamente las dependencias y las guarda en un volumen, por lo que los siguientes arranques son inmediatos. Además, los cambios en los archivos dentro de `frontend/` se reflejan al instante gracias al montaje en caliente.
+
+### Opción 2: entorno local (sin Docker)
+
 ```bash
 # 1. Clonar repositorio
 git clone [url-del-repositorio]
@@ -203,9 +221,20 @@ npm install
 
 # 3. Configurar variables de entorno (ver arriba)
 
-# 4. Iniciar servidor de desarrollo  
-npm run dev
+# 4. Iniciar servidor de desarrollo
+npm run dev -- --host
 ```
+
+#### Build de producción con Docker
+
+Si quieres obtener una imagen lista para desplegar estáticamente puedes ejecutar:
+
+```bash
+docker build -f frontend/Dockerfile --target prod -t consultoria-frontend:prod frontend
+docker run -p 8080:80 consultoria-frontend:prod
+```
+
+El contenedor final usa **Nginx** y expone el build optimizado en `http://localhost:8080`.
 
 ## 📱 Funcionalidades por Rol
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,15 @@
-version: "3.9"
-
 services:
-  db:
-    image: postgres:16
-    container_name: db
-    environment:
-      POSTGRES_DB: consultoria
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: 2310
-    ports:
-      - "5432:5432"
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres -d consultoria"]
-      interval: 5s
-      timeout: 3s
-      retries: 15
-      start_period: 10s
-
-  backend:
-    build: ./backend
-    container_name: backend
-    env_file:
-      - ./backend/.env
-    depends_on:
-      db:
-        condition: service_healthy
-
-    volumes:
-      - ./backend:/app
-    ports:
-      - "8000:8000"
-    command: >
-      sh -c "python manage.py migrate &&
-             python manage.py runserver 0.0.0.0:8000"
-
   frontend:
-    build: ./frontend
     container_name: frontend
-    command: npm run dev -- --host
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
+    build:
+      context: ./frontend
+      target: dev
     ports:
       - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    command: npm run dev -- --host 0.0.0.0 --port 5173
 
 volumes:
-  pgdata:
+  frontend_node_modules:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+.git
+.gitignore
+npm-debug.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,29 @@
-# Frontend development Dockerfile
-FROM node:20
+# syntax=docker/dockerfile:1.7
 
+FROM node:20-alpine AS deps
 WORKDIR /app
-
-ENV NODE_ENV=development
-
 COPY package.json package-lock.json* ./
-RUN npm install
+RUN npm ci
 
+FROM node:20-alpine AS dev
+WORKDIR /app
+ENV NODE_ENV=development
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
+RUN chmod +x docker-entrypoint.sh
 EXPOSE 5173
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
 
-CMD ["npm", "run", "dev", "--", "--host"]
+FROM node:20-alpine AS build
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS prod
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+LOCKFILE="package-lock.json"
+HASH_FILE="node_modules/.package-lock.hash"
+
+if [ ! -f "$LOCKFILE" ]; then
+  echo "No se encontró $LOCKFILE; ejecutando npm install" >&2
+  npm install
+  mkdir -p node_modules
+  if [ -f "$LOCKFILE" ]; then
+    sha256sum "$LOCKFILE" | awk '{ print $1 }' > "$HASH_FILE"
+  else
+    sha256sum package.json | awk '{ print $1 }' > "$HASH_FILE"
+  fi
+else
+  CURRENT_HASH="$(sha256sum "$LOCKFILE" | awk '{ print $1 }')"
+  if [ ! -d node_modules ] || [ ! -f "$HASH_FILE" ] || [ "$(cat "$HASH_FILE")" != "$CURRENT_HASH" ]; then
+    npm ci
+    mkdir -p node_modules
+    echo "$CURRENT_HASH" > "$HASH_FILE"
+  fi
+fi
+
+exec "$@"

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -15,7 +15,7 @@ interface AuthContextValue {
   login: (email: string, password: string) => Promise<{ error: unknown }>;
   logout: () => Promise<void>;
 }
-
+// eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {

--- a/frontend/src/pages/dashboardCoordinador.tsx
+++ b/frontend/src/pages/dashboardCoordinador.tsx
@@ -1,10 +1,8 @@
-import React from "react";
-
-export default function DashboardProfesor(){
-    return(
-        <div>
-            <h2>Dashboard Profesor</h2>
-            <p>hola</p>
-        </div>
-    )
+export default function DashboardProfesor() {
+  return (
+    <div>
+      <h2>Dashboard Profesor</h2>
+      <p>hola</p>
+    </div>
+  );
 }

--- a/frontend/src/services/supabaseClient.ts
+++ b/frontend/src/services/supabaseClient.ts
@@ -1,4 +1,3 @@
-// filepath: c:\Users\overx\consultoria_informatica\frontend\src\services\supabaseClient.ts
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;


### PR DESCRIPTION
## Summary
- replace docker-compose with a frontend-only service that mounts the project and reuses a node_modules volume for fast reloads
- convert the frontend Dockerfile into a multi-stage setup with an entrypoint that installs dependencies when needed and produces a production-ready image
- document the Docker usage in the README and clean up small lint/build issues in the React codebase

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d33ceb76d4832baacd498ae243784c