### PR TITLE
Ensure frontend entrypoint validates cached dependencies

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -3,6 +3,15 @@ set -e
 
 LOCKFILE="package-lock.json"
 HASH_FILE="node_modules/.package-lock.hash"
+REQUIRED_PATHS="node_modules/.bin/vite node_modules/@supabase/supabase-js"
+
+append_reason() {
+  if [ -z "$REASONS" ]; then
+    REASONS="$1"
+  else
+    REASONS="$REASONS; $1"
+  fi
+}
 
 if [ ! -f "$LOCKFILE" ]; then
   echo "No se encontró $LOCKFILE; ejecutando npm install" >&2
@@ -15,7 +24,36 @@ if [ ! -f "$LOCKFILE" ]; then
   fi
 else
   CURRENT_HASH="$(sha256sum "$LOCKFILE" | awk '{ print $1 }')"
-  if [ ! -d node_modules ] || [ ! -f "$HASH_FILE" ] || [ "$(cat "$HASH_FILE")" != "$CURRENT_HASH" ]; then
+  SHOULD_INSTALL=0
+  REASONS=""
+
+  if [ ! -d node_modules ]; then
+    SHOULD_INSTALL=1
+    append_reason "missing node_modules directory"
+  fi
+
+  if [ ! -f "$HASH_FILE" ]; then
+    SHOULD_INSTALL=1
+    append_reason "missing $HASH_FILE"
+  else
+    SAVED_HASH="$(cat "$HASH_FILE")"
+    if [ "$SAVED_HASH" != "$CURRENT_HASH" ]; then
+      SHOULD_INSTALL=1
+      append_reason "package-lock.json hash changed"
+    fi
+  fi
+
+  for REQUIRED_PATH in $REQUIRED_PATHS; do
+    if [ ! -e "$REQUIRED_PATH" ]; then
+      SHOULD_INSTALL=1
+      append_reason "missing $REQUIRED_PATH"
+    fi
+  done
+
+  if [ "$SHOULD_INSTALL" -eq 1 ]; then
+    if [ -n "$REASONS" ]; then
+      echo "Reinstalando dependencias: $REASONS" >&2
+    fi
     npm ci
     mkdir -p node_modules
     echo "$CURRENT_HASH" > "$HASH_FILE"


### PR DESCRIPTION
## Summary
- verify cached dependencies by requiring node_modules, hash match, and key module paths before skipping npm ci
- log the reason when dependency reinstall is triggered

## Testing
- `docker compose build frontend` *(fails: docker not available in container environment)*
- `docker compose up --build` *(fails: docker not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38ca08bb8832b802c3aece008e63c