### PR TITLE
Improve student registration step flow and email verification

### DIFF
--- a/frontend/src/pages/registerEstudiantes.tsx
+++ b/frontend/src/pages/registerEstudiantes.tsx
@@ -181,6 +181,9 @@ const RegisterEstudiantes: React.FC = () => {
       ...prev,
       verificationCode: '',
     }));
+    setTimeout(() => {
+      codeRefs.current[0]?.focus();
+    }, 0);
   };
 
   const handleUseDifferentEmail = () => {
@@ -231,17 +234,12 @@ const RegisterEstudiantes: React.FC = () => {
     });
   };
 
-  const handleRegister = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const submitRegistration = async () => {
     setError('');
-
-    if (activeStep < steps.length - 1) {
-      handleNext();
-      return;
-    }
 
     if (!isStepTwoComplete) {
       setError('Revisa los datos de contacto y tus credenciales antes de registrar.');
+      setActiveStep(1);
       return;
     }
 
@@ -343,6 +341,17 @@ const RegisterEstudiantes: React.FC = () => {
     }
   };
 
+  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (activeStep < steps.length - 1) {
+      handleNext();
+      return;
+    }
+
+    void submitRegistration();
+  };
+
   return (
     <Box
       sx={{
@@ -394,7 +403,7 @@ const RegisterEstudiantes: React.FC = () => {
             </Alert>
           )}
 
-          <Box component="form" onSubmit={handleRegister}>
+          <Box component="form" onSubmit={handleFormSubmit}>
             <Box
               key={activeStep}
               sx={{
@@ -406,80 +415,84 @@ const RegisterEstudiantes: React.FC = () => {
               }}
             >
               {activeStep === 0 && (
-                <Box sx={{ maxWidth: 560, mx: 'auto' }}>
-                  <Grid container spacing={2}>
-                    <Grid item xs={12} sm={6}>
-                      <TextField
-                        name="nombre"
-                        label="Nombre"
-                        value={formData.nombre}
-                        onChange={handleChange}
-                        fullWidth
-                        required
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <Person color="action" />
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
+                <Box
+                  sx={{
+                    width: '100%',
+                    maxWidth: { xs: '100%', md: 720 },
+                    mx: 'auto',
+                  }}
+                >
+                  <Grid container spacing={{ xs: 2, sm: 3 }} alignItems="stretch">
+                    <Grid item xs={12} md={6}>
+                      <Stack spacing={2} sx={{ height: '100%' }}>
+                        <TextField
+                          name="nombre"
+                          label="Nombre"
+                          value={formData.nombre}
+                          onChange={handleChange}
+                          fullWidth
+                          required
+                          InputProps={{
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <Person color="action" />
+                              </InputAdornment>
+                            ),
+                          }}
+                        />
+                        <TextField
+                          name="rut"
+                          label="RUT"
+                          placeholder="12.345.678-9"
+                          value={formData.rut}
+                          onChange={handleChange}
+                          fullWidth
+                          required
+                          InputProps={{
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <AssignmentInd color="action" />
+                              </InputAdornment>
+                            ),
+                          }}
+                        />
+                      </Stack>
                     </Grid>
 
-                    <Grid item xs={12} sm={6}>
-                      <TextField
-                        name="apellido"
-                        label="Apellido"
-                        value={formData.apellido}
-                        onChange={handleChange}
-                        fullWidth
-                        required
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <Person color="action" />
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
-                    </Grid>
-
-                    <Grid item xs={12} sm={6}>
-                      <TextField
-                        name="rut"
-                        label="RUT"
-                        placeholder="12.345.678-9"
-                        value={formData.rut}
-                        onChange={handleChange}
-                        fullWidth
-                        required
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <AssignmentInd color="action" />
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
-                    </Grid>
-
-                    <Grid item xs={12} sm={6}>
-                      <TextField
-                        name="telefono"
-                        type="tel"
-                        label="Teléfono"
-                        placeholder="+56 9 1234 5678"
-                        value={formData.telefono}
-                        onChange={handleChange}
-                        fullWidth
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <Phone color="action" />
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
+                    <Grid item xs={12} md={6}>
+                      <Stack spacing={2} sx={{ height: '100%' }}>
+                        <TextField
+                          name="apellido"
+                          label="Apellido"
+                          value={formData.apellido}
+                          onChange={handleChange}
+                          fullWidth
+                          required
+                          InputProps={{
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <Person color="action" />
+                              </InputAdornment>
+                            ),
+                          }}
+                        />
+                        <TextField
+                          name="telefono"
+                          type="tel"
+                          label="Teléfono"
+                          placeholder="+56 9 1234 5678"
+                          value={formData.telefono}
+                          onChange={handleChange}
+                          fullWidth
+                          InputProps={{
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <Phone color="action" />
+                              </InputAdornment>
+                            ),
+                          }}
+                        />
+                      </Stack>
                     </Grid>
                   </Grid>
                 </Box>
@@ -541,11 +554,20 @@ const RegisterEstudiantes: React.FC = () => {
                       )}
                       {emailPhase === 'code' && (
                         <Typography
-                          variant="subtitle2"
+                          variant="caption"
                           color={timerExpired ? 'error.main' : 'text.secondary'}
-                          sx={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}
+                          sx={{
+                            fontVariantNumeric: 'tabular-nums',
+                            fontWeight: 600,
+                            letterSpacing: 1,
+                          }}
                         >
                           {formattedTimer}
+                        </Typography>
+                      )}
+                      {timerExpired && (
+                        <Typography variant="caption" color="error" sx={{ fontWeight: 600 }}>
+                          El código expiró. Puedes solicitar uno nuevo.
                         </Typography>
                       )}
                       <Button
@@ -646,23 +668,25 @@ const RegisterEstudiantes: React.FC = () => {
                           />
                         ))}
                       </Box>
-                      <Button
-                        variant={timerExpired ? 'contained' : 'outlined'}
-                        color={timerExpired ? 'secondary' : 'inherit'}
-                        onClick={handleResendCode}
-                        type="button"
-                        sx={{
-                          minWidth: 200,
-                          '@keyframes pulseAccent': {
-                            '0%': { boxShadow: '0 0 0 0 rgba(156, 39, 176, 0.4)' },
-                            '70%': { boxShadow: '0 0 0 12px rgba(156, 39, 176, 0)' },
-                            '100%': { boxShadow: '0 0 0 0 rgba(156, 39, 176, 0)' },
-                          },
-                          animation: timerExpired ? 'pulseAccent 1.6s ease-in-out infinite' : 'none',
-                        }}
-                      >
-                        Reenviar código
-                      </Button>
+                      {timerExpired && (
+                        <Button
+                          variant="contained"
+                          color="secondary"
+                          onClick={handleResendCode}
+                          type="button"
+                          sx={{
+                            minWidth: 200,
+                            '@keyframes pulseAccent': {
+                              '0%': { boxShadow: '0 0 0 0 rgba(156, 39, 176, 0.4)' },
+                              '70%': { boxShadow: '0 0 0 12px rgba(156, 39, 176, 0)' },
+                              '100%': { boxShadow: '0 0 0 0 rgba(156, 39, 176, 0)' },
+                            },
+                            animation: 'pulseAccent 1.6s ease-in-out infinite',
+                          }}
+                        >
+                          Reenviar código
+                        </Button>
+                      )}
                     </Stack>
                   )}
 


### PR DESCRIPTION
## Summary
- reorganize the first registration step into two balanced columns so identity fields fill the available space cleanly
- add a compact 30-second countdown and expose the resend button only when verification codes expire
- restrict the Supabase signup request to the final step so the user is only created after finishing the program details

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e56dbee2a4832b8ed0a70860266447