### PR TITLE
Refine student dashboard layout and add FAQ page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import PracticaProfesionalForm from './pages/PracticaProfesionalForm';
 import CoordinadorPracticas from './pages/coordinadorPracticas';
 import CoordinadorEstudiantes from './pages/coordinadorEstudiantes';
 import CoordinadorEmpresas from './pages/coordinadorEmpresas';
+import PreguntasFrecuentes from './pages/preguntasFrecuentes';
 
 function App() {
   return (
@@ -50,6 +51,7 @@ function App() {
                 <Route path='/estudiante/fichapractica' element={<PracticaProfesionalForm />} />
                 <Route path="/estudiante/adjuntar_informes" element={<AdjuntarInformes />} />
                 <Route path="/estudiante/retroalimentacion" element={<Retroalimentacion />} />
+                <Route path="/estudiante/preguntas-frecuentes" element={<PreguntasFrecuentes />} />
               </Route>
             
               // Rutas para el rol de coordinador

--- a/frontend/src/pages/PracticaProfesionalForm.tsx
+++ b/frontend/src/pages/PracticaProfesionalForm.tsx
@@ -1,6 +1,7 @@
 // src/pages/PracticaProfesionalForm.tsx
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
+import DashboardTemplate from '../components/DashboardTemplate';
 import {
   Container,
   Paper,
@@ -540,7 +541,8 @@ const PracticaProfesionalForm: React.FC = () => {
   // Disable submit if we don't have the necessary user/estudiante to create records.
 
   return (
-    <Container component="main" maxWidth="md">
+    <DashboardTemplate>
+      <Container component="main" maxWidth="md">
       <Paper elevation={3} sx={{ p: 4, mt: 4 }}>
         <Typography
           component="h1"
@@ -822,6 +824,7 @@ const PracticaProfesionalForm: React.FC = () => {
         </Box>
       </Paper>
     </Container>
+    </DashboardTemplate>
   );
 };
 

--- a/frontend/src/pages/SeleccionPractica.tsx
+++ b/frontend/src/pages/SeleccionPractica.tsx
@@ -36,7 +36,7 @@ const SeleccionPractica: React.FC = () => {
   };
 
   return (
-    <DashboardTemplate title="">
+    <DashboardTemplate>
       <Box sx={{ mt: 4, mb: 6, px: 2 }}>
         {/* Título general */}
         <Typography

--- a/frontend/src/pages/preguntasFrecuentes.tsx
+++ b/frontend/src/pages/preguntasFrecuentes.tsx
@@ -1,0 +1,26 @@
+import { Box, List, ListItem, ListItemText, Typography } from '@mui/material';
+import DashboardTemplate from '../components/DashboardTemplate';
+
+export default function PreguntasFrecuentes() {
+  return (
+    <DashboardTemplate title="Preguntas frecuentes">
+      <Box sx={{ maxWidth: 720, mx: 'auto' }}>
+        <Typography variant="h4" gutterBottom fontWeight={600}>
+          Preguntas frecuentes
+        </Typography>
+        <Typography variant="body1" color="text.secondary" paragraph>
+          Estamos preparando la información más solicitada por los estudiantes. A continuación encontrarás un mock
+          temporal mientras definimos los contenidos definitivos.
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemText primary="1. Mock" secondary="Respuesta en desarrollo" />
+          </ListItem>
+          <ListItem>
+            <ListItemText primary="r Mock" secondary="Respuesta en desarrollo" />
+          </ListItem>
+        </List>
+      </Box>
+    </DashboardTemplate>
+  );
+}


### PR DESCRIPTION
## Summary
- refresh the shared dashboard template with a logo header, responsive sidebar behaviour, and a persistent title display
- wrap the student practice form and selection flow in the template so navigation and headers remain visible on every view
- add a frequently asked questions page and link it from the student navigation drawer

## Testing
- npm run lint *(fails: repository already contains numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e56fbe767c832b914bbbaeea81bb97