### PR TITLE
Replace dashboard banner text with PractiK logo

### DIFF
--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -218,14 +218,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 3 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 180, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}
@@ -249,14 +247,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 2 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 160, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}


### PR DESCRIPTION
## Summary
- replace the sidebar banner text in the dashboard template with the PractiK image from the public assets

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated files such as dashboardEstudiante.tsx and registerEstudiantes.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e5797b077c832b913979904eb54e5c