### PR TITLE
Replace dashboard branding assets

### DIFF
--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -218,14 +218,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 3 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 180, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}
@@ -249,14 +247,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 2 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 160, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}
@@ -291,18 +287,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
               </IconButton>
             )}
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Avatar
-                variant="rounded"
-                sx={{
-                  bgcolor: theme.palette.primary.main,
-                  width: 44,
-                  height: 44,
-                  mr: 2,
-                  fontWeight: 700
-                }}
-              >
-                UA
-              </Avatar>
+              <Box
+                component="img"
+                src="/UA.svg"
+                alt="UA"
+                sx={{ width: 44, height: 44, mr: 2, objectFit: 'contain' }}
+              />
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                 <Typography variant="h6" lineHeight={1.15} fontWeight={600}>
                   {headerTitle}


### PR DESCRIPTION
## Summary
- replace the sidebar banner text in the dashboard template with the PractiK image from the public assets
- swap the dashboard header badge for the UA.svg logo image

## Testing
- npm run build *(fails: existing TypeScript errors in coordinadorPracticas.tsx, dashboardEstudiante.tsx, registerEstudiantes.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e5797b077c832b913979904eb54e5c