### PR TITLE
Match UA badge frame to brand color

### DIFF
--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -218,14 +218,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 3 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 180, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}
@@ -249,14 +247,12 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
           }}
         >
           <Toolbar sx={{ justifyContent: 'center', py: 2 }}>
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h6" sx={{ fontWeight: 700, color: '#fff' }}>
-                BAN<span style={{ color: theme.palette.primary.main }}>NER</span>
-              </Typography>
-              <Typography variant="caption" sx={{ color: '#d0d0d0' }}>
-                Universidad Autónoma de Chile
-              </Typography>
-            </Box>
+            <Box
+              component="img"
+              src="/PractiK.png"
+              alt="PractiK"
+              sx={{ maxWidth: 160, width: '100%', objectFit: 'contain' }}
+            />
           </Toolbar>
           <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
           {renderMenuItems}
@@ -291,18 +287,27 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
               </IconButton>
             )}
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Avatar
-                variant="rounded"
+              <Box
                 sx={{
-                  bgcolor: theme.palette.primary.main,
-                  width: 44,
-                  height: 44,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 52,
+                  height: 52,
                   mr: 2,
-                  fontWeight: 700
+                  borderRadius: '14px',
+                  bgcolor: '#e2211c',
+                  p: 1,
+                  boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.04)'
                 }}
               >
-                UA
-              </Avatar>
+                <Box
+                  component="img"
+                  src="/UA.svg"
+                  alt="UA"
+                  sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                />
+              </Box>
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                 <Typography variant="h6" lineHeight={1.15} fontWeight={600}>
                   {headerTitle}


### PR DESCRIPTION
## Summary
- wrap the UA header logo inside a padded, rounded container so it mimics the previous badge spacing
- match the UA header logo frame color to the UA brand red (#e2211c) so the padded look blends with the artwork

## Testing
- npm --prefix frontend run build *(fails: existing TypeScript errors in coordinadorPracticas.tsx, dashboardEstudiante.tsx, registerEstudiantes.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e5797b077c832b913979904eb54e5c