### PR TITLE
feat: allow debugging delay for loading screen

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -74,3 +74,13 @@ Este repo incluye un ejemplo para enviar notificaciones al coordinador cuando un
 - Instrucciones de despliegue en: `supabase_functions/send_coordinator_notification/README.md`
 
 Sigue las instrucciones del README de la función para desplegarla y configurar las variables de entorno (por ejemplo, `SENDGRID_API_KEY` y `FROM_EMAIL`).
+
+## Depuración: forzar la pantalla de carga
+
+Si quieres ver la animación de `LoadingScreen` sin depender de retrasos reales en Supabase, puedes pedirle al proveedor de autenticación que simule una espera estableciendo la variable de entorno `VITE_DEBUG_AUTH_DELAY_MS` (valor en milisegundos). Por ejemplo:
+
+```bash
+VITE_DEBUG_AUTH_DELAY_MS=4000 npm run dev
+```
+
+También puedes añadir la variable al archivo `.env` de Vite mientras desarrollas. Con cualquier valor mayor que `0`, la app mantendrá el estado de carga durante el tiempo indicado, lo que te permite validar la pantalla de carga en todas las rutas protegidas.

--- a/frontend/src/components/DashboardTemplate.tsx
+++ b/frontend/src/components/DashboardTemplate.tsx
@@ -43,6 +43,7 @@ import {
 import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useTheme } from '@mui/material/styles';
+import LoadingScreen from './LoadingScreen';
 
 interface DashboardTemplateProps {
   title?: string;
@@ -103,11 +104,7 @@ export default function DashboardTemplate({ title, children }: DashboardTemplate
   const items = resolvedRole === 'coordinador' ? menuCoordinador : menuEstudiante;
 
   if (loading || roleLoading) {
-    return (
-      <Box display="flex" alignItems="center" justifyContent="center" minHeight="100vh">
-        <Typography>Cargando...</Typography>
-      </Box>
-    );
+    return <LoadingScreen />;
   }
 
   if (!currentUser) {

--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { keyframes } from '@mui/system';
+import { styled } from '@mui/material/styles';
+
+const spinMorph = keyframes`
+  0% {
+    transform: rotate(0deg);
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+  20% {
+    transform: rotate(270deg);
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+  25% {
+    transform: rotate(315deg);
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  }
+  40% {
+    transform: rotate(360deg);
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  }
+  60% {
+    transform: rotate(450deg);
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  }
+  70% {
+    transform: rotate(540deg);
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  }
+  75% {
+    transform: rotate(600deg);
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+  90% {
+    transform: rotate(720deg);
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+  100% {
+    transform: rotate(720deg);
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+`;
+
+const MorphingShape = styled('div')(({ theme }) => ({
+  width: 72,
+  height: 72,
+  background: `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+  borderRadius: 12,
+  animation: `${spinMorph} 2.8s infinite`,
+  animationTimingFunction: 'linear',
+  transformOrigin: '50% 50%',
+  willChange: 'transform, clip-path',
+  boxShadow: `0 10px 30px ${theme.palette.primary.main}33`,
+}));
+
+export function LoadingScreen() {
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 3,
+        bgcolor: 'background.default',
+        color: 'text.primary',
+        transition: 'background-color 0.3s ease',
+      }}
+    >
+      <MorphingShape />
+      <Typography variant="h6" component="p" sx={{ fontWeight: 500, letterSpacing: 1 }}>
+        Cargando experiencia...
+      </Typography>
+    </Box>
+  );
+}
+
+export default LoadingScreen;

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import LoadingScreen from './LoadingScreen';
 
 interface ProtectedRouteProps {
   allowedRole?: 'estudiante' | 'coordinador';
@@ -23,7 +24,7 @@ function roleMatches(allowed: string | undefined, actual: string | undefined) {
 
 export default function ProtectedRoute({ allowedRole, children }: ProtectedRouteProps) {
   const { isAuthenticated, currentUser, loading, role, roleLoading } = useAuth();
-  if (loading || roleLoading) return null;
+  if (loading || roleLoading) return <LoadingScreen />;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   const actualRole = (role ?? (currentUser as any)?.role) as string | undefined;
   if (allowedRole) {

--- a/frontend/src/components/RouteGuard.tsx
+++ b/frontend/src/components/RouteGuard.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "../hooks/useAuth";
 import { Navigate, Outlet } from "react-router-dom";
+import LoadingScreen from "./LoadingScreen";
 
 interface AuthGuardProps {
     roleAllowed?: 'estudiante' | 'coordinador';
@@ -10,7 +11,7 @@ export const RouteGuard = ({roleAllowed}: AuthGuardProps) => {
     if (!isAuthenticated) {
         return <Navigate to="/login" />
     }
-    if (roleLoading) return null
+    if (roleLoading) return <LoadingScreen />
     // resolve role (normalize legacy 'student' to 'estudiante')
     const resolved = (role ?? (currentUser as any)?.role) as string | undefined;
     const normalized = resolved === 'student' ? 'estudiante' : resolved;

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -4,6 +4,12 @@ import { AuthContext } from "../contexts/AuthContext"
 import { supabase } from "../services/supabaseClient"
 import type { Session, User } from "@supabase/supabase-js"
 
+const debugDelayRaw = Number(import.meta.env.VITE_DEBUG_AUTH_DELAY_MS ?? 0)
+const DEBUG_AUTH_DELAY_MS = Number.isFinite(debugDelayRaw) && debugDelayRaw > 0 ? debugDelayRaw : 0
+const maybeDelay = DEBUG_AUTH_DELAY_MS > 0
+  ? () => new Promise<void>(resolve => setTimeout(resolve, DEBUG_AUTH_DELAY_MS))
+  : () => Promise.resolve()
+
 const normalizeRole = (raw?: string | null): 'estudiante' | 'coordinador' | null => {
   if (!raw) return null
   const lowered = raw.toLowerCase()
@@ -65,6 +71,7 @@ export const AuthProvider = ({children}: AuthProviderProps) => {
       setCurrentUser(user)
       setRoleLoading(true)
       setRole(extractRole(user))
+      await maybeDelay()
       setRoleLoading(false)
       setLoading(false)
     }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DEBUG_AUTH_DELAY_MS?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- allow AuthProvider to simulate a loading delay when VITE_DEBUG_AUTH_DELAY_MS is set
- document how to enable the delay to preview the LoadingScreen animation
- type the new environment variable in vite-env.d.ts

## Testing
- npm run build *(fails: existing TypeScript errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e57d51e7dc832ba55e54914dfa1ea2